### PR TITLE
Fix autoload

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ use randomhost\NotifyMyAndroid\Client as NmaClient;
 $nmaClient = new NmaClient();
 
 $notification = new NotifyMyAndroid($nmaClient);
+$notification->setOptions(
+    getopt(
+        $notification->getShortOptions(),
+        $notification->getLongOptions()
+    )
+);
 $notification->run();
 
 echo $notification->getMessage();

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "randomhost/icinga": "~0.2"
+        "randomhost/icinga": "~0.2.1",
+        "randomhost/notifymyandroid": "~0.0.2"
     },
     "require-dev": {
         "behat/behat": "~2.0",

--- a/src/bin/icinga-notify-nma-push
+++ b/src/bin/icinga-notify-nma-push
@@ -12,9 +12,27 @@ namespace randomhost\Icinga\Notification;
 
 use randomhost\NotifyMyAndroid\Client as NmaClient;
 
-require_once realpath(__DIR__ . '/../../vendor') . '/autoload.php';
+// require autoload.php
+$paths = array(
+    __DIR__ . '/../../../../autoload.php',
+    __DIR__ . '/../../../vendor/autoload.php',
+    __DIR__ . '/../../vendor/autoload.php',
+);
+foreach ($paths as $autoload) {
+    if (file_exists($autoload)) {
+        require $autoload;
+        break;
+    }
+}
+unset($paths, $autoload);
 
 $notification = new NotifyMyAndroid(new NmaClient());
+$notification->setOptions(
+    getopt(
+        $notification->getShortOptions(),
+        $notification->getLongOptions()
+    )
+);
 $notification->run();
 
 echo $notification->getMessage();


### PR DESCRIPTION
- fix `autoload.php` path when used as vendor binary
- add missing `Base::setOptions()` calls
- add missing `randomhost/notifymyandroid` dependency
